### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single Go web app (`harvestovertimeweb`): Echo + [templ](https://templ.guide/) + HTMX,
+server-rendered. It computes Harvest overtime. Entry point is `main.go`; it starts an HTTP
+server on `$PORT` (see `.env`). Standard commands live in `.air.toml` and
+`.github/workflows/go.yml`.
+
+### Services & how to run them
+
+| Service | Command | Notes |
+|---|---|---|
+| Web app (dev, hot reload) | `air` | Uses `.air.toml`; runs `templ generate && go build` then serves on `$PORT` (8080). |
+| Web app (plain) | `go run .` | Uses committed `*_templ.go`; no regeneration. |
+| Build | `go build ./...` | CI equivalent: `go build -v ./...`. |
+| Test | `go test ./...` | No `*_test.go` files exist yet, so this is currently a no-op (CI still runs it). |
+| Vet | `go vet ./...` | No project-specific linter configured. |
+
+The dev tools `templ` and `air` are installed via `go install` into `$(go env GOPATH)/bin`
+(`/home/ubuntu/go/bin`), which is added to `PATH` in `~/.bashrc`. If `air`/`templ` are not
+found, run `export PATH="$PATH:$(go env GOPATH)/bin"`.
+
+### Non-obvious caveats
+
+- **`air` regenerates `view/*_templ.go` on every run** (its build cmd is `templ generate && ...`).
+  The committed files were generated with an older templ version, so running `air`/`templ generate`
+  produces a 1-line version-comment diff in `view/details_templ.go`, `view/index_templ.go`,
+  `view/shared_templ.go`. This is harmless — do NOT commit that churn (`git checkout -- view/*_templ.go`).
+- **`.env` is gitignored** and must exist for the app to start cleanly. It needs:
+  `PORT`, `HARVEST_CLIENT_ID`, `HARVEST_CLIENT_SECRET`, `USER_AGENT`, `SECRET`, and the DB vars
+  `DATABASE`, `DB_HOST`, `DB_USER`, `DB_PASS`, `DB_PORT`. Note `example.env` is missing the DB vars.
+- **PostgreSQL is optional but improves fidelity.** It only supplies Norwegian holidays and the
+  "years" list (table `dates`, columns `calendar,date,description`, filtered on `calendar='NO'`).
+  All DB errors are swallowed — the app still renders without a DB, just without holidays/years.
+  There is no migration/seed file in the repo; the `dates` table must be created and seeded manually.
+  Postgres is installed in this VM (cluster `16 main`, db `harvest`, user/pass `harvest/harvest`,
+  seeded `dates`). Start it with `sudo pg_ctlcluster 16 main start` (the update script does NOT
+  start services). `lib/pq` uses `sslmode=require` by default (the connection string has no
+  `sslmode`); the local cluster has SSL enabled, so it connects fine.
+- **Auth is external:** `/` requires an `accesstoken` cookie, otherwise it 307-redirects to `/auth`
+  → Harvest OAuth (`id.getharvest.com`), which needs a real Harvest account + registered OAuth app.
+  `POST /hours` and the OAuth callback cannot be exercised end-to-end without real Harvest
+  credentials. To view the rendered form locally without Harvest, set a dummy cookie
+  (e.g. `document.cookie="accesstoken=devtoken"` in the browser console, or `curl -b accesstoken=x`);
+  the page renders with DB-backed years but live time-entry data / the "Get Hours" calculation
+  require valid Harvest auth.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for `harvestovertimeweb` (Go + Echo + templ + HTMX) so future Cloud Agents can build, run, and test it.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting services, run/build/test/vet commands, and non-obvious caveats (templ regeneration churn, gitignored `.env`, optional Postgres for holidays/years, external Harvest OAuth).

The update script (configured separately, not committed) refreshes dependencies on VM startup:
```
go mod download
go install github.com/a-h/templ/cmd/templ@v0.3.857
go install github.com/air-verse/air@latest
```

## Environment details

- Go 1.23.4 (auto-provisioned via `go.mod` toolchain).
- Dev tools `templ` and `air` installed to `$(go env GOPATH)/bin` (added to `~/.bashrc`).
- Local PostgreSQL 16 with db/user `harvest`, seeded `dates` table (Norwegian holidays) to back the holidays/years feature. Start with `sudo pg_ctlcluster 16 main start`.
- `.env` (gitignored) created with `PORT`, dummy Harvest creds, `SECRET`, and DB vars.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- App runs via `air` on `:8080`; `GET /` redirects (307) to `/auth` → Harvest OAuth when unauthenticated, and renders the overtime form (200) with an `accesstoken` cookie.
- The "Select years to add holidays for" checkboxes (2024/2025/2026) are populated from PostgreSQL, confirming DB connectivity end-to-end.

[harvest_overtime_form_demo.mp4](https://cursor.com/agents/bc-a5664422-273a-4b36-b58f-5611f755c565/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fharvest_overtime_form_demo.mp4)

[Overtime form rendered with DB-backed years](https://cursor.com/agents/bc-a5664422-273a-4b36-b58f-5611f755c565/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Findex_page_loaded.webp)
[Form after toggling 2026 and editing work day hours](https://cursor.com/agents/bc-a5664422-273a-4b36-b58f-5611f755c565/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fform_interactive.webp)

Note: `POST /hours` and the OAuth callback require real Harvest credentials and cannot be exercised end-to-end in this environment.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5664422-273a-4b36-b58f-5611f755c565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5664422-273a-4b36-b58f-5611f755c565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

